### PR TITLE
Added OctoMap setup instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This repository contains the software for the [MCAV MiniDrone project](https://s
 ## Requirements
 It is recommended to install and run this project using docker. See [Docker Instructions](./docker/README.md).
 
+OctoMap (https://octomap.github.io/) is a mapping library that can be used to generate probabilistic occupancy grids and heightmaps. To setup OctoMap for use with ROS2, the following can be done:
+1. Install and build OctoMap libraries: https://github.com/OctoMap/octomap/wiki/Compilation-and-Installation-of-OctoMap
+    * NOTE: package libqglviewer-dev-qt4 is unavailable for Ubuntu 20.04. Can be replaced with libqglviewer-dev-qt5.
+2. Install ROS2 server in appropriate workspace: https://github.com/iKrishneel/octomap_server2
+
 ## Installation
 `git clone https://github.com/Monash-Connected-Autonomous-Vehicle/minidrone.git`
 


### PR DESCRIPTION
Appended OctoMap install instructions to requirements section, unsure if there is a more appropriate place. May benefit from using ros1 bridge instead of separate ros2 server - would appreciate advice.